### PR TITLE
macOS QoL improvements + toggle tray visibility

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -33,6 +33,14 @@
               <input type="range" min="0" max="100" value="20" step="5" class="slider mb-0" id="volume" style="width: 100%" />
             </td>
           </tr>
+          <tr class="checkbox-group" id="tray_icon_toggle_group">
+            <td style="width: 50%">Show Tray Icon</td>
+            <td style="width: 50%">
+              <div style="display:grid;grid-template-columns: 1em auto;font-size: 2rem;justify-content:right;">
+                <input type="checkbox" class="checkbox mb-0" id="tray_icon_toggle" checked/>
+              </div>
+            </td>
+          </tr>
         </tbody>
       </table>
       <div class="divider"></div>

--- a/src/app.js
+++ b/src/app.js
@@ -15,6 +15,7 @@ const remapper = require('./utils/remapper');
 
 const MV_PACK_LSID = 'mechvibes-pack';
 const MV_VOL_LSID = 'mechvibes-volume';
+const MV_TRAY_LSID = 'mechvibes-hidden';
 
 const CUSTOM_PACKS_DIR = remote.getGlobal('custom_dir');
 const OFFICIAL_PACKS_DIR = path.join(__dirname, 'audio');
@@ -206,6 +207,8 @@ function packsToOptions(packs, pack_list) {
     const pack_list = document.getElementById('pack-list');
     const volume_value = document.getElementById('volume-value-display');
     const volume = document.getElementById('volume');
+    const tray_icon_toggle = document.getElementById("tray_icon_toggle");
+    const tray_icon_toggle_group = document.getElementById("tray_icon_toggle_group");
 
     // set app version
     version.innerHTML = APP_VERSION;
@@ -236,6 +239,27 @@ function packsToOptions(packs, pack_list) {
 
     // get last selected pack
     current_pack = getPack();
+
+    // handle tray hiding
+    console.log(store.get(MV_TRAY_LSID));
+    if (store.get(MV_TRAY_LSID) !== undefined){
+      tray_icon_toggle.checked = store.get(MV_TRAY_LSID);
+    }
+    tray_icon_toggle.onclick = function(e) { 
+      let value = tray_icon_toggle.checked;
+      ipcRenderer.send("hide_tray_icon", !value);
+      store.set(MV_TRAY_LSID, value);
+    }
+    tray_icon_toggle_group.onclick = function(e) {
+      tray_icon_toggle.click();
+    }
+
+    // ensure tray icon is reflected
+    let initTray = () => {
+      let value = tray_icon_toggle.checked;
+      ipcRenderer.send("hide_tray_icon", !value);
+    }
+    initTray();
 
     // display volume value
     if (store.get(MV_VOL_LSID)) {

--- a/src/assets/app.css
+++ b/src/assets/app.css
@@ -112,3 +112,65 @@ table tr td {
 table {
   margin-bottom: 0;
 }
+
+:root {
+  --checkbox-color: #ff5050;
+  --checkbox-background: #fff;
+}
+
+.checkbox{
+  /* Add if not using autoprefixer */
+  -webkit-appearance: none;
+  /* Remove most all native input styles */
+  appearance: none;
+  /* For iOS < 15 */
+  background-color: var(--checkbox-background);
+  /* Not removed via appearance */
+  margin: 0;
+
+  opacity: 0.7;
+  -webkit-transition: 0.2s;
+  transition: opacity 0.2s;
+
+  font: inherit;
+  color: currentColor;
+  width: 1.15em;
+  height: 1.15em;
+  border: 0.15em solid currentColor;
+  border-radius: 0.15em;
+  transform: translateY(-0.075em);
+
+  display: grid!important;
+  place-content: center;
+}
+
+.checkbox::before{
+  content: "";
+  width: 0.65em;
+  height: 0.65em;
+  clip-path: polygon(14% 44%, 0 65%, 50% 100%, 100% 16%, 80% 0%, 43% 62%);
+  opacity:0;
+  transition: 200ms opacity ease-in-out;
+  box-shadow: inset 1em 1em var(--checkbox-color);
+  /* Windows High Contrast Mode */
+  background-color: CanvasText;
+}
+
+.checkbox-group{
+  user-select: none;
+  cursor: pointer;
+}
+
+/* Mouse-over effects */
+.checkbox-group:hover .checkbox {
+  opacity: 1;
+  /* Fully shown on mouse-over */
+}
+
+.checkbox:checked::before {
+  opacity:1;
+}
+
+.checkbox:focus {
+  outline: none;
+}


### PR DESCRIPTION
This PR adds some QoL improvements to macOS builds, such as making it so that right click can quickly open the main window, since double click doesn't work (atleast on my M1 macbook pro it doesn't.) as well as allowing the application to be minimized normally, and fixing an issue where attempting to open the app via launchpad or finder caused nothing to happen (where it should've been opening the app's preferences window)

This PR also adds the ability to hide the tray icon, so that the app can run _entirely_ in the background. When running like this, due to the prior mentioned fix, the preferences window can be opened by finding the app in launchpad or finder and attempting to open it.

Note that, the tray icon logic is retained on windows and linux, so double click is still the default there. However the minimize function has been stripped from all three, so it will minimize as a normal window or app on all three OS's.