### PR TITLE
Apply rules of consistency to the tray icon checkbox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 out
 dist
 *.
+.DS_Store

--- a/src/app.js
+++ b/src/app.js
@@ -245,19 +245,23 @@ function packsToOptions(packs, pack_list) {
     if (store.get(MV_TRAY_LSID) !== undefined){
       tray_icon_toggle.checked = store.get(MV_TRAY_LSID);
     }
-    tray_icon_toggle.onclick = function(e) { 
-      let value = tray_icon_toggle.checked;
-      ipcRenderer.send("hide_tray_icon", !value);
-      store.set(MV_TRAY_LSID, value);
-    }
+    // tray_icon_toggle.onclick = function(e) { 
+    //   e.preventDefault();
+    //   e.stopPropagation();
+    //   tray_icon_toggle_group.click();
+    // }
     tray_icon_toggle_group.onclick = function(e) {
-      tray_icon_toggle.click();
+      e.preventDefault();
+      e.stopPropagation();
+      // toggle checkbox
+      tray_icon_toggle.checked = !tray_icon_toggle.checked;
+      ipcRenderer.send("show_tray_icon", tray_icon_toggle.checked);
+      store.set(MV_TRAY_LSID, tray_icon_toggle.checked);
     }
 
     // ensure tray icon is reflected
     let initTray = () => {
-      let value = tray_icon_toggle.checked;
-      ipcRenderer.send("hide_tray_icon", !value);
+      ipcRenderer.send("show_tray_icon", tray_icon_toggle.checked);
     }
     initTray();
 

--- a/src/assets/app.css
+++ b/src/assets/app.css
@@ -142,6 +142,8 @@ table {
 
   display: grid!important;
   place-content: center;
+
+  pointer-events: none;
 }
 
 .checkbox::before{

--- a/src/main.js
+++ b/src/main.js
@@ -179,8 +179,10 @@ if (!gotTheLock) {
       }
     }
 
-    ipcMain.on("hide_tray_icon", (event, hide) => {
-      if(hide && tray !== null){
+    ipcMain.on("show_tray_icon", (event, show) => {
+      if(show && tray === null){
+        createTrayIcon();
+      }else if(!show && tray !== null){
         tray.destroy()
         tray = null;
       }else if(!hide && tray === null){


### PR DESCRIPTION
The HTML checkbox is labeled "Show Tray Icon", and so this PR moves to provide consistency between app.js and main.js to match that wording, as well as fixing an issue with click regions causing inconsistent behaviour depending on where you clicked on the "Show Tray Icon" row.

This PR also adds .DS_Store files to .gitignore as they were previously omitted.