### PR TITLE
Update

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -347,7 +347,7 @@ function packsToOptions(packs, pack_list) {
     if (store.get(MV_VOL_LSID)) {
       volume.value = store.get(MV_VOL_LSID);
     }else{
-      // TODO:
+      // TODO: set default
     }
     volume_value.innerHTML = volume.value;
     volume.oninput = function (e) {

--- a/src/app.js
+++ b/src/app.js
@@ -139,10 +139,12 @@ function getPack(pack_id = null, is_random = false) {
     if (store.get(MV_PACK_LSID)) {
       pack_id = store.get(MV_PACK_LSID);
       if (is_random) {
+        const pack_list = document.getElementById('pack-list');
         const randomId = Math.floor(Math.random() * packs.length);
         if (packs[randomId].pack_id === current_pack.pack_id) {
           getPack(null, true);
         }
+        pack_list.selectedIndex = randomId;
         return packs[randomId];
       }
       if (!getPack(pack_id)) {
@@ -333,6 +335,7 @@ function packsToOptions(packs, pack_list) {
     // on random button click
     // set random sound
     random_button.addEventListener('click', (e) => {
+      console.log("clicked random");
       e.preventDefault();
       current_pack = getPack(null, true);
     });

--- a/src/app.js
+++ b/src/app.js
@@ -396,7 +396,7 @@ function packsToOptions(packs, pack_list) {
       // get loaded audio object
       // if object valid, pack volume and play sound
       if (current_pack) {
-        playSound(sound_id, store.get(MV_VOL_LSID));
+        playSound(sound_id, volume.value);
       }
     });
 

--- a/src/app.js
+++ b/src/app.js
@@ -47,7 +47,7 @@ function loadPack(packId = null){
         const audio = new Howl(sound_data);
         audio.once('load', function () {
           packs[packId].sound = audio;
-          resolve(true);
+          resolve();
         });
       }else{
         let loaded_sounds = {};
@@ -59,8 +59,8 @@ function loadPack(packId = null){
             }
           });
           if(!unloaded_exists){
-            console.log("done");
             packs[packId].sound = loaded_sounds;
+            resolve();
           }
         }
         Object.keys(pack.sound_data).map((kc) => {
@@ -113,10 +113,7 @@ window.unloadPack = unloadPack;
 
 // ==================================================
 // load all pack
-async function loadPacks(status_display_elem, app_body) {
-  // init
-  status_display_elem.innerHTML = 'Loading...';
-
+async function loadPacks() {
   // get all audio folders
   const official_packs = await glob.sync(OFFICIAL_PACKS_DIR + '/*/');
   const custom_packs = await glob.sync(CUSTOM_PACKS_DIR + '/*/');
@@ -292,6 +289,9 @@ function packsToOptions(packs, pack_list) {
     const tray_icon_toggle = document.getElementById("tray_icon_toggle");
     const tray_icon_toggle_group = document.getElementById("tray_icon_toggle_group");
 
+    // init
+    app_logo.innerHTML = 'Loading...';
+
     // set app version
     version.innerHTML = APP_VERSION;
 
@@ -321,7 +321,10 @@ function packsToOptions(packs, pack_list) {
 
     // get last selected pack
     current_pack = getSavedPack();
-    loadPack();
+    loadPack().then(() => {
+      app_logo.innerHTML = 'Mechvibes';
+      app_body.classList.remove('loading');
+    });
 
     // handle tray hiding
     console.log(store.get(MV_TRAY_LSID));

--- a/src/app.js
+++ b/src/app.js
@@ -28,6 +28,89 @@ let is_muted = store.get('mechvibes-muted') || false;
 const packs = [];
 const all_sound_files = {};
 
+function loadPack(packId = null){
+  if(packId === null){
+    Object.keys(packs).map((pid) => {
+      const _pack = packs[pid];
+      if(_pack.id == current_pack.id){
+        packId = pid;
+      }
+    })
+  }
+  return new Promise((resolve, reject) => {
+    if(packs[packId] !== undefined){
+      unloadAllPacks(); // unload all loaded packs before attempting to load a new pack.
+      const pack = packs[packId];
+      if(pack.key_define_type == 'single'){
+        const sound_data = packs[packId].sound_data;
+        
+        const audio = new Howl(sound_data);
+        audio.once('load', function () {
+          packs[packId].sound = audio;
+          resolve(true);
+        });
+      }else{
+        let loaded_sounds = {};
+        let check = () => {
+          let unloaded_exists = false;
+          Object.keys(loaded_sounds).map((key) => {
+            if (typeof loaded_sounds[key] !== 'object') {
+              unloaded_exists = true;
+            }
+          });
+          if(!unloaded_exists){
+            console.log("done");
+            packs[packId].sound = loaded_sounds;
+          }
+        }
+        Object.keys(pack.sound_data).map((kc) => {
+          const audio = new Howl(pack.sound_data[kc]);
+          loaded_sounds[kc] = false;
+          audio.once('load', function(){
+            loaded_sounds[kc] = audio;
+            check();
+          })
+        })
+      }
+    }else{
+      reject("That packID doesn't exist");
+    }
+  })
+}
+
+function unloadPack(packId){
+  if(packs[packId] !== undefined){
+    if(packs[packId].sound !== undefined){
+      if(packs[packId].key_define_type == 'single'){
+        packs[packId].sound.unload();
+        delete packs[packId].sound;
+      }else{
+        Object.keys(packs[packId].sound).map((kc) => {
+          packs[packId].sound[kc].unload();
+        })
+        delete packs[packId].sound;
+      }
+      return [true];
+    }else{
+      return [false, "pack is unloaded already"];
+    }
+  }else{
+    return [false, "pack doesn't exist"];
+  }
+}
+
+function unloadAllPacks(){
+  Object.keys(packs).map((packId) => {
+    if(packs[packId].sound !== undefined){
+      unloadPack(packId);
+    }
+  })
+}
+
+window.packs = packs;
+window.loadPack = loadPack;
+window.unloadPack = unloadPack;
+
 // ==================================================
 // load all pack
 async function loadPacks(status_display_elem, app_body) {
@@ -69,31 +152,19 @@ async function loadPacks(status_display_elem, app_body) {
       if (key_define_type == 'single') {
         // define sound path
         const sound_path = `${folder}${sound}`;
-        const sound_data = new Howl({ src: [sound_path], sprite: keycodesRemap(defines) });
-        Object.assign(pack_data, { sound: sound_data });
-        all_sound_files[pack_data.pack_id] = false;
-        // event when sound loaded
-        sound_data.once('load', function () {
-          all_sound_files[pack_data.pack_id] = true;
-          checkIfAllSoundLoaded(status_display_elem, app_body);
-        });
+        const sound_data = { src: [sound_path], sprite: keycodesRemap(defines) };
+        Object.assign(pack_data, { sound_data: sound_data });
       } else {
         const sound_data = {};
         Object.keys(defines).map((kc) => {
           if (defines[kc]) {
             // define sound path
             const sound_path = `${folder}${defines[kc]}`;
-            sound_data[kc] = new Howl({ src: [sound_path] });
-            all_sound_files[`${pack_data.pack_id}-${kc}`] = false;
-            // event when sound_data loaded
-            sound_data[kc].once('load', function () {
-              all_sound_files[`${pack_data.pack_id}-${kc}`] = true;
-              checkIfAllSoundLoaded(status_display_elem, app_body);
-            });
+            sound_data[kc] = { src: [sound_path] };
           }
         });
         if (Object.keys(sound_data).length) {
-          Object.assign(pack_data, { sound: keycodesRemap(sound_data) });
+          Object.assign(pack_data, { sound_data: keycodesRemap(sound_data) });
         }
       }
   
@@ -107,19 +178,6 @@ async function loadPacks(status_display_elem, app_body) {
 }
 
 // ==================================================
-// check if all packs loaded
-function checkIfAllSoundLoaded(status_display_elem, app_body) {
-  Object.keys(all_sound_files).map((key) => {
-    if (!all_sound_files[key]) {
-      return false;
-    }
-  });
-  status_display_elem.innerHTML = 'Mechvibes';
-  app_body.classList.remove('loading');
-  return true;
-}
-
-// ==================================================
 // remap keycodes from standard to os based keycodes
 function keycodesRemap(defines) {
   const sprite = remapper('standard', platform, defines);
@@ -130,32 +188,44 @@ function keycodesRemap(defines) {
   return sprite;
 }
 
-// ==================================================
-// get pack by id or random,
-// if id is null,
-// get saved pack
-function getPack(pack_id = null, is_random = false) {
-  if (!pack_id) {
-    if (store.get(MV_PACK_LSID)) {
-      pack_id = store.get(MV_PACK_LSID);
-      if (is_random) {
-        const pack_list = document.getElementById('pack-list');
-        const randomId = Math.floor(Math.random() * packs.length);
-        if (packs[randomId].pack_id === current_pack.pack_id) {
-          getPack(null, true);
-        }
-        pack_list.selectedIndex = randomId;
-        return packs[randomId];
-      }
-      if (!getPack(pack_id)) {
-        return packs[0];
-      }
-    } else {
-      return packs[0];
-    }
-  }
-  store.set(MV_PACK_LSID, pack_id);
+function getPack(pack_id){
   return packs.find((pack) => pack.pack_id == pack_id);
+}
+
+function getSavedPack() {
+  if (store.get(MV_PACK_LSID)) {
+    const pack_id = store.get(MV_PACK_LSID);
+    const pack = getPack(pack_id);
+    if (!pack) {
+      return packs[0];
+    }else{
+      return pack;
+    }
+  } else {
+    return packs[0];
+  }
+}
+
+// set pack by its index in the packs array
+function setPack(pack_id){
+  let index = 0;
+  Object.keys(packs).map((packId) => {
+    if(packs[packId].pack_id == pack_id){
+      index = packId;
+    }
+  })
+  loadPack(index);
+  current_pack = packs[index];
+  store.set(MV_PACK_LSID, current_pack.pack_id);
+}
+
+window.store = store;
+
+// set pack by its string id
+function setPackByIndex(index){
+  loadPack(index);
+  current_pack = packs[index];
+  store.set(MV_PACK_LSID, current_pack.pack_id);
 }
 
 // ==================================================
@@ -186,7 +256,7 @@ function packsToOptions(packs, pack_list) {
       const is_selected = selected_pack_id == pack.pack_id;
       if (is_selected) {
         // pack current pack to saved pack
-        current_pack = pack;
+        setPack(pack.pack_id);
       }
       // add pack to pack list
       const opt = document.createElement('option');
@@ -202,8 +272,7 @@ function packsToOptions(packs, pack_list) {
   // update saved list id
   pack_list.addEventListener('change', (e) => {
     const selected_id = e.target.options[e.target.selectedIndex].value;
-    store.set(MV_PACK_LSID, selected_id);
-    current_pack = getPack();
+    setPack(selected_id);
   });
 }
 
@@ -251,18 +320,14 @@ function packsToOptions(packs, pack_list) {
     });
 
     // get last selected pack
-    current_pack = getPack();
+    current_pack = getSavedPack();
+    loadPack();
 
     // handle tray hiding
     console.log(store.get(MV_TRAY_LSID));
     if (store.get(MV_TRAY_LSID) !== undefined){
       tray_icon_toggle.checked = store.get(MV_TRAY_LSID);
     }
-    // tray_icon_toggle.onclick = function(e) { 
-    //   e.preventDefault();
-    //   e.stopPropagation();
-    //   tray_icon_toggle_group.click();
-    // }
     tray_icon_toggle_group.onclick = function(e) {
       e.preventDefault();
       e.stopPropagation();
@@ -281,6 +346,8 @@ function packsToOptions(packs, pack_list) {
     // display volume value
     if (store.get(MV_VOL_LSID)) {
       volume.value = store.get(MV_VOL_LSID);
+    }else{
+      // TODO:
     }
     volume_value.innerHTML = volume.value;
     volume.oninput = function (e) {
@@ -311,6 +378,7 @@ function packsToOptions(packs, pack_list) {
     // key pressed, pack current key and play sound
     iohook.on('keydown', ({ keycode }) => {
       // if hold down a key, not repeat the sound
+      // On macOS this doesn't seem to be an issue?
       if (current_key_down != null && current_key_down == keycode) {
         return;
       }
@@ -335,9 +403,17 @@ function packsToOptions(packs, pack_list) {
     // on random button click
     // set random sound
     random_button.addEventListener('click', (e) => {
-      console.log("clicked random");
       e.preventDefault();
-      current_pack = getPack(null, true);
+      let getRandomPackId = () => {
+        let randomId = Math.floor(Math.random() * packs.length);
+        if (packs[randomId].pack_id === current_pack.pack_id) {
+          return getRandomPackId();
+        }
+        return randomId;
+      }
+      const packId = getRandomPackId();
+      pack_list.selectedIndex = packId;
+      setPackByIndex(packId);
     });
   });
 })(window, document);
@@ -345,6 +421,10 @@ function packsToOptions(packs, pack_list) {
 // ==================================================
 // universal play function
 function playSound(sound_id, volume) {
+  if(current_pack.sound === undefined){
+    // sound for this pack hasn't been loaded
+    return;
+  }
   const play_type = current_pack.key_define_type ? current_pack.key_define_type : 'single';
   const sound = play_type == 'single' ? current_pack.sound : current_pack.sound[sound_id];
   if (!sound) {

--- a/src/main.js
+++ b/src/main.js
@@ -198,7 +198,7 @@ if (!gotTheLock) {
       }else if(!show && tray !== null){
         tray.destroy()
         tray = null;
-      }else if(!hide && tray === null){
+      }else if(!show && tray === null){
         createTrayIcon();
       }
     })


### PR DESCRIPTION
This PR introduces a handful of overhaul like changes to app.js as well as a minor fix to main.js

- Introduces loadPack and unloadPack to allow only loading the currently selected soundpack, as well as modifying the loadPacks function to only store the options for howl instead of storing an entire howl object. This change saves approximately 300mb of ram over previous versions.
- Simplifies getPack and introduces getSavedPack
- Adds setPack and setPackByIndex which unify the setting of current_pack, saving of MV_PACK_LSID, and loading the soundpack's sounds.
- rewrites the random sound picker's code.
- Uses the value of our volume selector instead of calling store.get to decide our volume for playSound
- Adds an escape route to playSound for when we try to play an unloaded soundpack (which shouldn't happen, but yeknow.)