### PR TITLE
ensure v2.3.10 is newer than v2.3.9 when checking if an update is available.

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -366,7 +366,7 @@ function packsToOptions(packs, pack_list) {
     fetch('https://api.github.com/repos/hainguyents13/mechvibes/releases/latest')
       .then((res) => res.json())
       .then((json) => {
-        if (json.tag_name > APP_VERSION) {
+        if (json.tag_name.localeCompare(APP_VERSION, undefined, { numeric: true }) === 1) {
           new_version.innerHTML = json.tag_name;
           update_available.classList.remove('hidden');
         }


### PR DESCRIPTION
comparing the github version against the app version using the `>` operator, could sometimes result in unexpected results. such as `2.3.9` being "newer" than `2.3.10`

Note however that, there is one unexpected result with the new comparison, if github says 2.3.5.0 and the app says 2.3.5, there may be a "update available" message when there shouldn't be.