### PR TITLE
Make it so mechvibes can process zip files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,16 @@
       "version": "v2.3.5",
       "license": "MIT",
       "dependencies": {
+        "adm-zip": "^0.5.10",
         "easy-volume": "^1.1.0",
         "electron-fetch": "^1.9.1",
         "electron-log": "^4.4.8",
         "electron-store": "^6.0.0",
         "fs-extra": "^9.0.1",
         "glob": "^7.1.6",
-        "howler": "^2.1.2",
-        "iohook": "^0.9.3"
+        "howler": "^2.2.4",
+        "iohook": "^0.9.3",
+        "mime-types": "^2.1.35"
       },
       "devDependencies": {
         "electron": "^12.2.3",
@@ -256,6 +258,14 @@
       "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-5.1.1.tgz",
       "integrity": "sha512-sAP4LldeWNz0lNzmTird3uWfFDWWTeg6V/MsmyyLR9X1idwKBWIgt/ZvinqQldJm3LecKEs1emkbquO6PCiLVQ==",
       "dev": true
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.10.tgz",
+      "integrity": "sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ==",
+      "engines": {
+        "node": ">=6.0"
+      }
     },
     "node_modules/agent-base": {
       "version": "6.0.2",
@@ -4200,6 +4210,11 @@
       "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-5.1.1.tgz",
       "integrity": "sha512-sAP4LldeWNz0lNzmTird3uWfFDWWTeg6V/MsmyyLR9X1idwKBWIgt/ZvinqQldJm3LecKEs1emkbquO6PCiLVQ==",
       "dev": true
+    },
+    "adm-zip": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.10.tgz",
+      "integrity": "sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ=="
     },
     "agent-base": {
       "version": "6.0.2",

--- a/package.json
+++ b/package.json
@@ -88,14 +88,16 @@
     }
   },
   "dependencies": {
+    "adm-zip": "^0.5.10",
     "easy-volume": "^1.1.0",
     "electron-fetch": "^1.9.1",
     "electron-log": "^4.4.8",
     "electron-store": "^6.0.0",
     "fs-extra": "^9.0.1",
     "glob": "^7.1.6",
-    "howler": "^2.1.2",
-    "iohook": "^0.9.3"
+    "howler": "^2.2.4",
+    "iohook": "^0.9.3",
+    "mime-types": "^2.1.35"
   },
   "devDependencies": {
     "electron": "^12.2.3",

--- a/src/app.js
+++ b/src/app.js
@@ -109,11 +109,16 @@ function _loadPack(packId){
         }
         Object.keys(pack.sound_data).map((kc) => {
           const audio = new Howl(pack.sound_data[kc]);
-          loaded_sounds[kc] = false;
-          audio.once('load', function(){
+          if(audio.state() == "loaded"){
             loaded_sounds[kc] = audio;
             check();
-          })
+          }else{
+            loaded_sounds[kc] = false;
+            audio.once('load', function(){
+              loaded_sounds[kc] = audio;
+              check();
+            })
+          }
         })
       }
     }else{

--- a/src/app.js
+++ b/src/app.js
@@ -264,7 +264,7 @@ async function loadPacks() {
               return;
             }
             const file = files[defines[kc]];
-            sound_data[kc] = { src: [file.src], format: file.type };
+            sound_data[kc] = { src: [file] };
           }
         });
         if (Object.keys(sound_data).length) {

--- a/src/app.js
+++ b/src/app.js
@@ -154,8 +154,8 @@ function unloadAllPacks(){
 // load all pack
 async function loadPacks() {
   // get all audio folders
-  const official_packs = await glob.sync(OFFICIAL_PACKS_DIR + '/*/');
-  const custom_packs = await glob.sync(CUSTOM_PACKS_DIR + '/*/');
+  const official_packs = await glob.sync(OFFICIAL_PACKS_DIR + '/*');
+  const custom_packs = await glob.sync(CUSTOM_PACKS_DIR + '/*');
   const folders = [...official_packs, ...custom_packs];
 
   // get pack data

--- a/src/app.js
+++ b/src/app.js
@@ -385,7 +385,6 @@ function packsToOptions(packs, pack_list) {
     loadPack()
 
     // handle tray hiding
-    console.log(store.get(MV_TRAY_LSID));
     if (store.get(MV_TRAY_LSID) !== undefined){
       tray_icon_toggle.checked = store.get(MV_TRAY_LSID);
     }

--- a/src/app.js
+++ b/src/app.js
@@ -236,7 +236,14 @@ async function loadPacks() {
         if(fileName == 'config.json'){
           files[fileName] = file.getData().toString('utf8');
         }else{
-          const mimeType = mime.lookup(fileName);
+          const _mimeType = mime.lookup(fileName);
+          // HACK: some soundpacks have mp4 files, which are actually audio files, and howler can play them but refuses
+          // to load them because it thinks they are video files. So we change the mimeType to audio/* but also mime.lookup
+          // doesn't seem to return a string, so we also need to convert it to a string.
+          let mimeType = `${_mimeType}`;
+          if(mimeType.substring(0, 6) == 'video/'){
+            mimeType = mimeType.replace('video/', 'audio/');
+          }
           files[fileName] = `data:${mimeType};base64,${file.getData().toString('base64')}`;
         }
       });

--- a/src/app.js
+++ b/src/app.js
@@ -103,23 +103,6 @@ function _loadPack(packId){
           }
         }
         Object.keys(pack.sound_data).map((kc) => {
-          let missing = false;
-          if(pack.sound_data[kc] !== undefined){
-            Object.keys(pack.sound_data[kc].src).map((i) => {
-              const path = pack.sound_data[kc].src[i];
-              console.log(path);
-              if(!fs.existsSync(path)){
-                missing = true;
-              }
-            })
-          }else{
-            missing = true;
-          }
-          if(missing){
-            // reject(5);
-            check();
-            return;
-          }
           const audio = new Howl(pack.sound_data[kc]);
           loaded_sounds[kc] = false;
           audio.once('load', function(){

--- a/src/app.js
+++ b/src/app.js
@@ -158,6 +158,10 @@ async function loadPacks() {
   const custom_packs = await glob.sync(CUSTOM_PACKS_DIR + '/*');
   const folders = [...official_packs, ...custom_packs];
 
+  log.info(`Loading ${folders.length} packs`);
+  log.debug(OFFICIAL_PACKS_DIR);
+  log.debug(CUSTOM_PACKS_DIR);
+
   // get pack data
   folders.map((folder) => {
     // get folder name

--- a/src/app.js
+++ b/src/app.js
@@ -283,6 +283,8 @@ async function loadPacks() {
         });
         if (Object.keys(sound_data).length) {
           Object.assign(pack_data, { sound_data: keycodesRemap(sound_data) });
+        }else{
+          return;
         }
       }
 

--- a/src/app.js
+++ b/src/app.js
@@ -232,7 +232,7 @@ async function loadPacks() {
         if(file.isDirectory){
           return;
         }
-        const fileName = path.basename(file.entryName);
+        const fileName = path.basename(file.entryName).toLowerCase();
         if(fileName == 'config.json'){
           files[fileName] = file.getData().toString('utf8');
         }else{
@@ -273,10 +273,11 @@ async function loadPacks() {
         Object.keys(defines).map((kc) => {
           if (defines[kc]) {
             // define sound path
-            if(files[defines[kc]] === undefined){
+            const definition = defines[kc].toLowerCase();
+            if(files[definition] === undefined){
               return;
             }
-            const file = files[defines[kc]];
+            const file = files[definition];
             sound_data[kc] = { src: [file] };
           }
         });

--- a/src/app.js
+++ b/src/app.js
@@ -74,8 +74,9 @@ function loadPack(packId = null){
     log.info("loaded");
     app_logo.innerHTML = 'Mechvibes';
     app_body.classList.remove('loading');  
-  }).catch(() => {
+  }).catch((e) => {
     app_logo.innerHTML = 'Failed';
+    log.warn(`Failed to load pack: ${e}`);
   });
 }
 

--- a/src/app.js
+++ b/src/app.js
@@ -66,6 +66,8 @@ function loadPack(packId = null){
   const app_body = document.getElementById('app-body');
 
   log.info(`Loading ${packId}`)
+  app_logo.innerHTML = 'Loading...';
+  app_body.classList.add('loading');
   _loadPack(packId).then(() => {
     log.info("loaded");
     app_logo.innerHTML = 'Mechvibes';

--- a/yarn.lock
+++ b/yarn.lock
@@ -150,6 +150,11 @@
   resolved "https://registry.npmjs.org/7zip-bin/-/7zip-bin-5.1.1.tgz"
   integrity sha512-sAP4LldeWNz0lNzmTird3uWfFDWWTeg6V/MsmyyLR9X1idwKBWIgt/ZvinqQldJm3LecKEs1emkbquO6PCiLVQ==
 
+adm-zip@^0.5.10:
+  version "0.5.10"
+  resolved "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.10.tgz"
+  integrity sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ==
+
 agent-base@6:
   version "6.0.2"
   resolved "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz"
@@ -1179,7 +1184,7 @@ hosted-git-info@^4.1.0:
   dependencies:
     lru-cache "^6.0.0"
 
-howler@^2.1.2:
+howler@^2.2.4:
   version "2.2.4"
   resolved "https://registry.npmjs.org/howler/-/howler-2.2.4.tgz"
   integrity sha512-iARIBPgcQrwtEr+tALF+rapJ8qSc+Set2GJQl7xT1MQzWaVkFebdJhR3alVlSiUf5U7nAANKuj3aWpwerocD5w==
@@ -1463,7 +1468,7 @@ mime-db@1.52.0:
   resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-types@^2.1.12, mime-types@~2.1.19:
+mime-types@^2.1.12, mime-types@^2.1.35, mime-types@~2.1.19:
   version "2.1.35"
   resolved "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==


### PR DESCRIPTION
Note: This is **only** for zip files. 7z, rar, tar, tar.gz are not supported.

Also note, that by choosing to use zip files, your memory usage will be higher, as sound files from zipped sound packs are kept in memory, wether you use them or not.