### PR TITLE
Add a Mute button to the main UI, sync it with Mute button in right-click menu

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -60,6 +60,14 @@
               </div>
             </td>
           </tr>
+          <tr class="checkbox-group" id="mute_toggle_group">
+            <td style="width: 50%">Mute</td>
+            <td style="width: 50%">
+              <div style="display: grid; grid-template-columns: 1em auto; font-size: 2rem; justify-content: right;">
+                <input type="checkbox" class="checkbox mb-1" id="mute_toggle" />
+              </div>
+            </td>
+          </tr>
         </tbody>
       </table>
       <div class="divider"></div>

--- a/src/app.js
+++ b/src/app.js
@@ -18,6 +18,8 @@ const remapper = require('./utils/remapper');
 const MV_PACK_LSID = remote.getGlobal("current_pack_store_id");
 const MV_VOL_LSID = 'mechvibes-volume';
 const MV_TRAY_LSID = 'mechvibes-hidden';
+const MV_MUTED = 'mechvibes-muted';
+const MV_STARTUP_ENABLED = 'mechvibes-startup-enabled';
 
 const CUSTOM_PACKS_DIR = remote.getGlobal('custom_dir');
 const OFFICIAL_PACKS_DIR = path.join(__dirname, 'audio');
@@ -413,6 +415,8 @@ function packsToOptions(packs, pack_list) {
     const volume = document.getElementById('volume');
     const tray_icon_toggle = document.getElementById("tray_icon_toggle");
     const tray_icon_toggle_group = document.getElementById("tray_icon_toggle_group");
+    const mute_toggle = document.getElementById("mute_toggle");
+    const mute_toggle_group = document.getElementById("mute_toggle_group");
 
     // init
     app_logo.innerHTML = 'Loading...';
@@ -459,6 +463,19 @@ function packsToOptions(packs, pack_list) {
       tray_icon_toggle.checked = !tray_icon_toggle.checked;
       ipcRenderer.send("show_tray_icon", tray_icon_toggle.checked);
       store.set(MV_TRAY_LSID, tray_icon_toggle.checked);
+    }
+
+    // handle mute
+    if (store.get(MV_MUTED) !== undefined){
+      mute_toggle.checked = store.get(MV_MUTED);
+    }
+    mute_toggle_group.onclick = function(e) {
+      e.preventDefault();
+      e.stopPropagation();
+      // toggle checkbox
+      mute_toggle.checked = !mute_toggle.checked;
+      ipcRenderer.send("set_mute", mute_toggle.checked);
+      store.set(MV_MUTED, mute_toggle.checked);
     }
 
     // ensure tray icon is reflected
@@ -521,8 +538,10 @@ function packsToOptions(packs, pack_list) {
     ipcRenderer.on("mechvibes-mute-status", (_event, enabled) => {
       if(enabled){
         mechvibes_muted.classList.remove("hidden");
+        mute_toggle.checked = true;
       }else{
         mechvibes_muted.classList.add("hidden");
+        mute_toggle.checked = false;
       }
     });
 


### PR DESCRIPTION
I find myself toggling the mute on and off fairly regularly. I have mechvibes enabled on startup, and I always have the UI open, so it's easy to access things there and a bit cumbersome to open the tray, right click mechvibes, and click the mute button. This PR adds a mute button to the UI which is synced with the right-click menu in the tray. 

![image](https://github.com/user-attachments/assets/483d0c9e-a052-416c-9b54-ee5fcbf67ce8)
![image](https://github.com/user-attachments/assets/a76b7ff1-61c4-4bc2-ac74-4162e71b56f2)
