### PR TITLE
fix: get property was_started_at_login instead of calling it on app start

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -404,7 +404,7 @@ if (!gotTheLock) {
     const startup_handler = new StartupHandler(app);
 
     log.silly("Creating main window for the first time...");
-    if(startup_handler.was_started_at_login() && start_minimized.is_enabled){
+    if(startup_handler.was_started_at_login && start_minimized.is_enabled){
       win = createWindow(false);
     }else{
     win = createWindow(true);


### PR DESCRIPTION
This is quite a dumb issue, lol. Anyways, here's a fix so people can boot 2.3.6 (which I am pretty sure should be 2.3.5 as stated in package.json, though).