### PR TITLE
Fix(sound): Disable background throttling to prevent sound delay

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -176,6 +176,7 @@ function createWindow(show = false) {
     name: "app", // used by logger to differentiate messages sent by different windows.
     width: 400,
     height: 600,
+    backgroundThrottling: false,
     webSecurity: false,
     // resizable: false,
     // fullscreenable: false,


### PR DESCRIPTION
This change sets `backgroundThrottling: false` for the main application window.

Electron's default behavior is to throttle renderer processes when a window is in the background (e.g., minimized to the system tray or hidden). This throttling is suspected to be the cause of the reported sound delay on the first keystroke after the application has been idle or minimized.

By disabling background throttling, the renderer process should remain more responsive, allowing it to process keyboard events and play sounds without the initial delay. This addresses issue #13 where you experience a sound lag on the first keypress after the app is idle or minimized.