### PR TITLE
feat: support Apple Silicon (arm64) macOS builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ Follow these steps:
   - For Windows: `yarn build:win`
   - For Linux: `yarn build:linux`
 
+On macOS, `yarn build:mac` produces both Intel (x64) and Apple Silicon
+(arm64) builds. The arm64 build requires compiling the `iohook` native
+module from source (its 0.9.3 release ships no arm64 prebuilt binary);
+`scripts/build-iohook.js` does this automatically as part of the build
+and only rebuilds when the binary for your platform is missing.
+
 That’s it, your app is ready to use!
 
 ## Have Feedback or Suggestions?

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "electron .",
     "build:all": "electron-builder -wml",
     "build:win": "electron-builder -w",
-    "build:mac": "electron-builder -m",
+    "build:mac": "node scripts/build-iohook.js && electron-builder -m",
     "build:linux": "electron-builder -l",
     "build:clean": "node tools/clean-dist.js"
   },
@@ -56,7 +56,8 @@
         {
           "target": "dmg",
           "arch": [
-            "x64"
+            "x64",
+            "arm64"
           ]
         }
       ],
@@ -101,6 +102,7 @@
   },
   "devDependencies": {
     "electron": "^12.2.3",
-    "electron-builder": "^24.13.3"
+    "electron-builder": "^24.13.3",
+    "node-abi": "^4.33.0"
   }
 }

--- a/scripts/build-iohook.js
+++ b/scripts/build-iohook.js
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+/**
+ * Builds the iohook native module from source for the current platform/arch
+ * when no prebuilt binary is available.
+ *
+ * Why this exists: iohook 0.9.3 (2020) only ships prebuilt binaries for
+ * linux/win32/darwin x64 (and win32 ia32). On Apple Silicon (darwin-arm64)
+ * there is no prebuilt `iohook.node`, so the packaged app crashes at startup
+ * with "Cannot find module .../electron-v87-darwin-arm64/.../iohook.node"
+ * and keyboard click sounds never work.
+ *
+ * The npm tarball also does NOT include the libuiohook source (it is a git
+ * submodule of the iohook repository), so node-gyp cannot build directly from
+ * node_modules/iohook. This script clones the tagged iohook source WITH
+ * submodules, compiles iohook.node against the project's Electron headers,
+ * and drops the binary into node_modules/iohook/builds/ so the subsequent
+ * electron-builder pass packages it into the app.
+ *
+ * Usage: node scripts/build-iohook.js   (runs automatically via build:mac)
+ */
+
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const ELECTRON_VERSION = require(path.join(ROOT, 'node_modules', 'electron', 'package.json')).version;
+const IOHOOK_VERSION = '0.9.3';
+const IOHOOK_GIT = 'https://github.com/wilix-team/iohook.git';
+const HEADERS_BASE = 'https://artifacts.electronjs.org/headers/dist';
+const ARCH = process.arch === 'arm64' ? 'arm64' : process.arch;
+
+const nodeAbi = require('node-abi');
+const ABI = nodeAbi.getAbi(ELECTRON_VERSION, 'electron'); // e.g. 87 for Electron 12
+
+const essential = `electron-v${ABI}-${process.platform}-${ARCH}`;
+const outDir = path.join(ROOT, 'node_modules', 'iohook', 'builds', essential, 'build', 'Release');
+const outFile = path.join(outDir, 'iohook.node');
+
+function run(cmd, args, opts = {}) {
+  console.log(`$ ${cmd} ${args.join(' ')}`);
+  return execFileSync(cmd, args, { stdio: 'inherit', ...opts });
+}
+
+function alreadyBuilt() {
+  return fs.existsSync(outFile);
+}
+
+function main() {
+  if (alreadyBuilt()) {
+    console.log(`iohook binary already present for ${essential}, skipping.`);
+    process.exit(0);
+  }
+
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'iohook-src-'));
+  console.log(`Building iohook ${IOHOOK_VERSION} for ${essential} in ${tmp} ...`);
+
+  try {
+    // 1. iohook source WITH libuiohook submodule (absent from the npm tarball)
+    run('git', ['clone', '--recursive', '--depth', '1', '--branch', `v${IOHOOK_VERSION}`, IOHOOK_GIT, tmp]);
+
+    // 2. node-gyp + nan (nan ships in iohook's devDeps; install without running
+    //    iohook's install script, which would try to download a prebuild)
+    run('npm', ['install', '--no-save', '--ignore-scripts', 'node-gyp@10.0.1', 'nan'], { cwd: tmp });
+
+    // 3. Electron headers for the exact runtime/ABI (atom.io/download/electron
+    //    is dead; artifacts.electronjs.org is the working mirror). The tarball
+    //    extracts a top-level `node_headers/` directory, so unpack into tmp.
+    const headersTar = path.join(tmp, 'node-headers.tar.gz');
+    const headersDir = path.join(tmp, 'node_headers');
+    const headersUrl = `${HEADERS_BASE}/v${ELECTRON_VERSION}/node-v${ELECTRON_VERSION}-headers.tar.gz`;
+    run('curl', ['-sL', '-o', headersTar, headersUrl]);
+    run('tar', ['-xzf', headersTar, '-C', tmp]);
+
+    // 4. Stage the darwin binding.gyp files (build.js copies these at build
+    //    time; they are not present at the package root in the npm tarball)
+    fs.copyFileSync(path.join(tmp, 'build_def', process.platform, 'binding.gyp'), path.join(tmp, 'binding.gyp'));
+    fs.copyFileSync(path.join(tmp, 'build_def', process.platform, 'uiohook.gyp'), path.join(tmp, 'uiohook.gyp'));
+
+    // 5. Patch Electron's common.gypi: newer gyp-next cannot evaluate the
+    //    `openssl_fips != ""` condition (name 'openssl_fips' is not defined).
+    //    FIPS is irrelevant for this addon, so drop the condition block.
+    const commonGypi = path.join(headersDir, 'include', 'node', 'common.gypi');
+    const common = fs.readFileSync(commonGypi, 'utf8');
+    const fipsCond = `      ['openssl_fips != ""', {
+        'openssl_product': '<(STATIC_LIB_PREFIX)crypto<(STATIC_LIB_SUFFIX)',
+      }, {
+        'openssl_product': '<(STATIC_LIB_PREFIX)openssl<(STATIC_LIB_SUFFIX)',
+      }],`;
+    if (common.includes(fipsCond)) {
+      fs.writeFileSync(commonGypi, common.replace(fipsCond, ''));
+      console.log('patched common.gypi: removed openssl_fips condition');
+    } else {
+      console.log('common.gypi: openssl_fips condition not found (already patched?), continuing');
+    }
+
+    // 6. Build. Flags mirror iohook's build.js for abi >= 80.
+    const gyp = path.join(tmp, 'node_modules', '.bin', 'node-gyp');
+    const args = [
+      'rebuild',
+      `--target=${ELECTRON_VERSION}`,
+      `--arch=${ARCH}`,
+      `--nodedir=${headersDir}`,
+      '--build_v8_with_gn=false',
+      '--enable_lto=false',
+    ];
+    if (ARCH === 'x64') {
+      args.push('--v8_enable_pointer_compression=1');
+    } else {
+      args.push('--v8_enable_pointer_compression=0');
+      args.push('--v8_enable_31bit_smis_on_64bit_arch=1');
+    }
+    run(gyp, args, { cwd: tmp });
+
+    // 7. Install the binary where iohook's index.js and electron-builder expect it
+    fs.mkdirSync(outDir, { recursive: true });
+    fs.copyFileSync(path.join(tmp, 'build', 'Release', 'iohook.node'), outFile);
+    console.log(`Installed iohook.node -> ${outFile}`);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+main();

--- a/yarn.lock
+++ b/yarn.lock
@@ -172,15 +172,11 @@
   resolved "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz"
   integrity sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==
 
-"7zip-bin@~5.1.1":
-  version "5.1.1"
-  resolved "https://registry.npmjs.org/7zip-bin/-/7zip-bin-5.1.1.tgz"
-  integrity sha512-sAP4LldeWNz0lNzmTird3uWfFDWWTeg6V/MsmyyLR9X1idwKBWIgt/ZvinqQldJm3LecKEs1emkbquO6PCiLVQ==
-
 adm-zip@^0.5.10:
   version "0.5.10"
   resolved "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.10.tgz"
   integrity sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ==
+
 agent-base@6:
   version "6.0.2"
   resolved "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz"
@@ -1600,6 +1596,13 @@ ms@2.1.2:
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
+node-abi@^4.33.0:
+  version "4.33.0"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-4.33.0.tgz#cce9b7bce0cbfa1d5d5a9b6908bc5eed698969cc"
+  integrity sha512-vLBWCKb+7LWsX+TbfzWOkw0W81m377tyx3hOweBTjO43CXZnRGS1/JPWs20fr0PgZyDXk6ROYrylsEycK8raDA==
+  dependencies:
+    semver "^7.6.3"
+
 node-addon-api@^1.6.3:
   version "1.7.2"
   resolved "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz"
@@ -1972,6 +1975,11 @@ semver@^7.3.8, semver@^7.5.3:
   integrity sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==
   dependencies:
     lru-cache "^6.0.0"
+
+semver@^7.6.3:
+  version "7.8.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.5.tgz#39b646037dd50c14fb451e7e4cac58ed8b863f69"
+  integrity sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==
 
 serialize-error@^7.0.1:
   version "7.0.1"


### PR DESCRIPTION
The electron-builder config only targeted x64, so on Apple Silicon machines the app ran under Rosetta and macOS flagged a component that will not work with a future release. Worse, the packaged app crashed at startup: iohook 0.9.3 ships no darwin-arm64 prebuilt binary, so the keyboard hook module was missing and click sounds never worked.

- Build both x64 and arm64 DMGs for macOS
- Add scripts/build-iohook.js: compiles the iohook native module from source (with its libuiohook submodule) against the pinned Electron headers when no prebuilt binary exists for the current platform/arch, and installs it into node_modules/iohook/builds/
- Wire the script into build:mac so arm64 builds work out of the box
- Document the behavior in the README

The npm tarball of iohook omits the libuiohook git submodule, so a plain node-gyp rebuild from node_modules/iohook is impossible; the script clones the tagged iohook source with submodules instead.